### PR TITLE
minecraft-shell::logs: Add allow not-running sever

### DIFF
--- a/src/minecraft-shell.sh
+++ b/src/minecraft-shell.sh
@@ -96,9 +96,13 @@ case "$CMD" in
 		systemctl --user status "minecraft@$CURRENT_SERVER"
 		;;
 	logs)
-		if [ -n "$1" ]; then
-			CURRENT_SERVER=$1
-		elif [ -z "$CURRENT_SERVER" ]; then
+		if [ "$#" -gt 0 ]; then
+			if [[ "$1" != -* ]]; then
+				CURRENT_SERVER="$1"
+				shift
+			fi
+		fi
+		if [ -z "$CURRENT_SERVER" ]; then
 			echo "No server running or specified."
 			exit 1
 		fi

--- a/src/minecraft-shell.sh
+++ b/src/minecraft-shell.sh
@@ -96,8 +96,10 @@ case "$CMD" in
 		systemctl --user status "minecraft@$CURRENT_SERVER"
 		;;
 	logs)
-		if [ -z "$CURRENT_SERVER" ]; then
-			echo "No server running."
+		if [ -n "$1" ]; then
+			CURRENT_SERVER=$1
+		elif [ -z "$CURRENT_SERVER" ]; then
+			echo "No server running or specified."
 			exit 1
 		fi
 		exec journalctl -q --user -u "minecraft@$CURRENT_SERVER" "$@"


### PR DESCRIPTION
Add an optional server-name argument to the "logs" command. This is to enable retrieving the logs when the server has crashed without starting it again.