### PR TITLE
hologram-bethselamin-synapse.pkg.toml: allow_guest_access

### DIFF
--- a/hologram-bethselamin-synapse.pkg.toml
+++ b/hologram-bethselamin-synapse.pkg.toml
@@ -140,7 +140,7 @@ content = '''
   bcrypt_rounds: 12
 
   # guest access
-  allow_guest_access: False
+  allow_guest_access: True
   trusted_third_party_id_servers:
       - matrix.org
       - vector.im


### PR DESCRIPTION
I cannot start private messages with people from IRC and some other matrix servers: https://github.com/matrix-org/synapse/pull/653
I am not sure what other implications this has or what the reason was to disable this in the first place.